### PR TITLE
Convert render_charts to simple tag for jinja2 support

### DIFF
--- a/wagtailcharts/templatetags/wagtailcharts_tags.py
+++ b/wagtailcharts/templatetags/wagtailcharts_tags.py
@@ -1,10 +1,11 @@
 from django import template
+from django.template.loader import render_to_string
 
 register = template.Library()
 
-@register.inclusion_tag('wagtailcharts/tags/render_charts.html')
-def render_charts():
-    pass
+@register.simple_tag(takes_context=True)
+def render_charts(context):
+    return render_to_string('wagtailcharts/tags/render_charts.html', context=context)
 
 @register.filter()
 def addspace(val):


### PR DESCRIPTION
This allows the tag to be called easily from jinja2:

```python
from wagtailcharts.templatetags.wagtailcharts_tags import render_charts
from jinja2 import pass_context

# later...
self.environment.globals.update(
    {
        "render_charts": pass_context(render_charts),
    }
)
```

The template doesn't use any context, but it's passed in anyway for backwards-compatibility (and because it's no real extra work).

Usage of the tag isn't changed, so this is non-breaking.